### PR TITLE
feat: Using --no-install-recommends (Optimization)

### DIFF
--- a/load-tester/Dockerfile
+++ b/load-tester/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:10.1-slim
 
 RUN echo "===> Installing  tools..."  && \
     apt-get -y update && \
-    apt-get -y install build-essential curl jq && \
+    apt-get --no-install-recommends -y install build-essential curl jq && \
     \
     echo "===> Installing wrk" && \
     WRK_VERSION=$(curl -L https://github.com/wg/wrk/raw/master/CHANGES 2>/dev/null | \

--- a/load-tester/Dockerfile
+++ b/load-tester/Dockerfile
@@ -17,7 +17,14 @@ RUN echo "===> Installing  tools..."  && \
     \
     echo "===> Cleaning the system" && \
     apt-get -f -y --auto-remove remove build-essential curl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /opt/wrk/
+    apt-get clean \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /opt/wrk \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base
 
 ADD report.lua .


### PR DESCRIPTION
Using a --no-install-recommends when apt-get installing packages.

This will result in a smaller image size.