### PR TITLE
Fix istio example

### DIFF
--- a/examples/istio/rollout.yaml
+++ b/examples/istio/rollout.yaml
@@ -36,7 +36,7 @@ spec:
         - templateName: istio-success-rate
         args:             # arguments allow AnalysisTemplates to be re-used
         - name: service 
-          value: canary
+          value: istio-rollout-canary
         - name: namespace
           valueFrom:
             fieldRef:


### PR DESCRIPTION
The service name is `istio-rollout-canary` and not `canary`