### PR TITLE
Fix: blue-green example doesn't work in k8s clusters from v1.22

### DIFF
--- a/examples/blue-green/bluegreen-ingress.yaml
+++ b/examples/blue-green/bluegreen-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bluegreen-demo
@@ -12,6 +12,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: bluegreen-demo
-          servicePort: 80
+          service:
+            name: bluegreen-demo
+            port:
+              number: 80

--- a/examples/blue-green/bluegreen-preview-ingress.yaml
+++ b/examples/blue-green/bluegreen-preview-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bluegreen-demo-preview
@@ -12,6 +12,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: bluegreen-demo-preview
-          servicePort: 80
+          service:
+            name: bluegreen-demo
+            port:
+              number: 80


### PR DESCRIPTION
The `networking.k8s.io/v1beta1` API version is no longer server as of v1.22.

K8s has new API version since v1.9 called `networking.k8s.io/v1`.

Currently the blue-green example cannot be deployed in a cluster of v.1.22 and above. 

The v1.19 was released August 2020. All the clusters created or updated since August 2020 can deploy this version.

More info: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122
