### PR TITLE
Fix istio demo: Internal request route not base on weight but replica count

### DIFF
--- a/examples/istio-subset/virtualservice.yaml
+++ b/examples/istio-subset/virtualservice.yaml
@@ -5,9 +5,11 @@ metadata:
 spec:
   gateways:
   - istio-rollout-gateway
+  - mesh
   hosts:
   - istio-rollout.apps.argoproj.io
   - istio-rollout.local
+  - istio-rollout.rollouts-demo-istio.svc.cluster.local
   http:
   - name: primary
     route:

--- a/examples/istio/virtualservice.yaml
+++ b/examples/istio/virtualservice.yaml
@@ -5,9 +5,11 @@ metadata:
 spec:
   gateways:
   - istio-rollout-gateway
+  - mesh
   hosts:
   - istio-rollout.apps.argoproj.io
   - istio-rollout.local
+  - istio-rollout-stable.rollouts-demo-istio.svc.cluster.local
   http:
   - name: primary
     route:


### PR DESCRIPTION
# Notes

Hi Team, I find the Istio demo (both `istio` and `istio-subset`) fine-grained, weighted traffic shifting feature has issue for internal request.

A lot of uses are learning from this demo and they maybe not expert in istio, so we'd better to fix it and provide best practice for them, otherwise we will misleading them.
(It is not easy for beginners to fix it by themselves, like me...)

Could you take some time to review it.
Thanks

# Architecture

The green path is external request, `istio-rollout.apps.argoproj.io/color` works well. because
* VirtualService `istio-rollout-vsvc` apply to `istio-rollout-gateway`, and external request go through istio-ingressgateway(istio-rollout-gateway)
* Host `istio-rollout.apps.argoproj.io` can be matched, so it can use `http.route` rule


The red path is internal request, because the VirtualService `istio-rollout-vsvc` not apply to service `mesh`, and `istio-rollout.rollouts-demo-istio.svc.cluster.local` go through mesh but not gateway, it only uses Service `istio-rollout`'s endpoints, `http.route` rule doesn't work for this request.
<img width="1230" alt="image" src="https://github.com/argoproj/rollouts-demo/assets/5286751/efafd530-823a-4d2f-a04d-2078fdbcf330">

# How to fix

The fix contains 2 parts.
* VirtualService `istio-rollout-vsvc` apply to `mesh`
* match hosts `{servie}.{namespace}.svc.cluster.local`, e.g. `istio-rollout.rollouts-demo-istio.svc.cluster.local`

