### PR TITLE
chore: add stable and canary labels

### DIFF
--- a/examples/analysis/rollout-with-analysis.yaml
+++ b/examples/analysis/rollout-with-analysis.yaml
@@ -16,6 +16,12 @@ spec:
         - name: ingress
           value: canary-demo
       canaryService: canary-demo-preview
+      stableMetadata:
+        labels:
+          role: stable
+      canaryMetadata:
+        labels:
+          role: canary
       steps:
       - setWeight: 40
       - pause: {}

--- a/examples/canary/canary-rollout.yaml
+++ b/examples/canary/canary-rollout.yaml
@@ -28,6 +28,12 @@ spec:
   strategy:
     canary:
       canaryService: canary-demo-preview
+      stableMetadata:
+        labels:
+          role: stable
+      canaryMetadata:
+        labels:
+          role: canary
       steps:
       - setWeight: 20
       - pause: {}


### PR DESCRIPTION
to canary rollouts