### PR TITLE
fix(rollouts): update analysis templateName to use templates array

### DIFF
--- a/examples/analysis/rollout-with-analysis.yaml
+++ b/examples/analysis/rollout-with-analysis.yaml
@@ -11,7 +11,8 @@ spec:
   strategy:
     canary:
       analysis:
-        templateName: success-rate
+        templates:
+        - templateName: success-rate
         args:
         - name: ingress
           value: canary-demo


### PR DESCRIPTION
When trying Argo Rollouts with the command:
kustomize build ./examples/analysis | kubectl apply -f -

Got error:
"Error from server (BadRequest): error when creating "STDIN": Rollout in 
version "v1alpha1" cannot be handled as a Rollout: strict decoding error: 
unknown field "spec.strategy.canary.analysis.templateName""

Fix: The templateName field needs to be nested under a 'templates' array 
in newer versions of Argo Rollouts. Updated the configuration to follow 
the current schema by wrapping templateName inside templates:

```
spec:
  strategy:
    canary:
      analysis:
        templates:
        - templateName: success-rate
```