### PR TITLE
Add comments to gateway.yaml

### DIFF
--- a/examples/istio/gateway.yaml
+++ b/examples/istio/gateway.yaml
@@ -3,6 +3,8 @@ kind: Gateway
 metadata:
   name: istio-rollout-gateway
 spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
   selector:
     istio: ingressgateway
   servers:


### PR DESCRIPTION
I spent forever troubleshooting why Istio wouldn't work and it ended up being the `istio: ingressgateway` selector on the Gateway resource. I needed to change it to `istio: ingress` since I installed Istio using Helm. I added comments to help out the next person!