### PR TITLE
feat: add multi-architecture (ARM64) support for rollouts-demo images

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,0 +1,53 @@
+name: Build and Push Multi-Arch Rollouts Demo Images
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: rollouts-demo-ambrosia
+  REGISTRY_USER: ambrosiaaaaa
+  REGISTRY: docker.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Make build script executable
+        run: chmod +x build-multiarch.sh
+
+      - name: Build and push images
+        run: |
+          SHOULD_PUSH=${{ github.event_name != 'pull_request' && 'true' || 'false' }}
+          IMAGE_PATH="${{ env.REGISTRY_USER }}/${{ env.IMAGE_NAME }}"
+          ./build-multiarch.sh ${{ env.REGISTRY }} $IMAGE_PATH $SHOULD_PUSH
+
+      - name: Check images (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          for TAG in blue green purple yellow; do
+            docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.REGISTRY_USER }}/${{ env.IMAGE_NAME }}:$TAG
+          done

--- a/build-multiarch.sh
+++ b/build-multiarch.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+REGISTRY=$1
+IMAGE_NAME=$2
+PUSH=$3  # true/false
+REGISTRY_USER=$4
+
+# Debug
+echo "Debug info:"
+echo "REGISTRY: ${REGISTRY}"
+echo "IMAGE_NAME: ${IMAGE_NAME}"
+echo "PUSH: ${PUSH}"
+
+TAGS=("slow-purple" "bad-purple" "purple" "slow-blue" "bad-blue" "blue" "slow-green" "bad-green" "green" "slow-yellow")
+
+for TAG in "${TAGS[@]}"; do
+    # Extract color and params
+    if [[ $TAG == slow-* ]]; then
+        COLOR=${TAG#slow-}
+        LATENCY="5000"
+        ERROR_RATE="0"
+    elif [[ $TAG == bad-* ]]; then
+        COLOR=${TAG#bad-}
+        LATENCY="0"
+        ERROR_RATE="50"
+    else
+        COLOR=$TAG
+        LATENCY="0"
+        ERROR_RATE="0"
+    fi
+    
+    # Debug
+    FULL_TAG="${REGISTRY}/${IMAGE_NAME}:${TAG}"
+    echo "Building tag: ${FULL_TAG}"
+    
+    # Build and push
+    docker buildx build \
+        --platform linux/amd64,linux/arm64 \
+        --build-arg COLOR=$COLOR \
+        --build-arg LATENCY=$LATENCY \
+        --build-arg ERROR_RATE=$ERROR_RATE \
+        -t ${FULL_TAG} \
+        ${PUSH:+"--push"} \
+        .
+done


### PR DESCRIPTION
# Add Multi-Architecture Support for Rollouts Demo Images

## What changes are being made?
- Added GitHub Actions workflow for building multi-arch images
- Added support for ARM64 architecture
- Added build script for generating all variants

## Why are these changes needed?
The current rollouts-demo images only support AMD64, making it impossible to run the demo on ARM-based systems like M1/M2 Macs or Raspberry Pi.

## How to verify it?
1. The workflow will build images for both AMD64 and ARM64;
2. Images can be tested on different architectures;
3. No changes to existing functionality.

## Setup
Required Secrets:
DOCKERHUB_TOKEN: Docker Hub access token
Environment variables (configured in workflow):

## Usage
Automatic Execution

The workflow runs automatically on:
* Push to main
* Pull Requests to main

## Manual Execution

* Go to "Actions" tab
* Select "Build and Push Multi-Arch Rollouts Demo Images"
* Click "Run workflow"
* Select branch
* Click "Run workflow"

## Notes to reviewers
- The current images won't be overwritten until approved
- We can use a different registry/tag for testing
- Can be merged after verification on different architectures
